### PR TITLE
Another API implementation

### DIFF
--- a/src/WebApi/Controllers/NotificationController.cs
+++ b/src/WebApi/Controllers/NotificationController.cs
@@ -2,9 +2,6 @@
 using System.Threading.Tasks;
 using Application.Handlers.CreateNotification;
 using Application.Handlers.GetNotificationStatus;
-using Domain.Enums;
-using Infrastructure.Services.AndroidNotification;
-using Infrastructure.Services.IOsNotification;
 using Microsoft.AspNetCore.Mvc;
 using WebApi.Models;
 

--- a/src/WebApi/Controllers/NotificationController.cs
+++ b/src/WebApi/Controllers/NotificationController.cs
@@ -6,31 +6,23 @@ using Domain.Enums;
 using Infrastructure.Services.AndroidNotification;
 using Infrastructure.Services.IOsNotification;
 using Microsoft.AspNetCore.Mvc;
+using WebApi.Models;
 
 namespace WebApi.Controllers
 {
     [Route("notification")]
     public class NotificationController : ApiController
     {
-        [HttpPost("create/android")]
-        public async Task<ActionResult> CreateAndroidNotification([FromBody] AndroidNotificationData data)
+        [HttpPost("create")]
+        public async Task<ActionResult> Create([FromBody] CreateNotificationModel model)
         {
-            var command = new CreateNotificationCommand
-            {
-                Notification = data,
-                Type = NotificationType.Android
-            };
-            var result = await Mediator.Send(command);
-            return Ok(result);
-        }
+            if (model is null)
+                return BadRequest();
 
-        [HttpPost("create/ios")]
-        public async Task<ActionResult> CreateIOsNotification([FromBody] IOsNotificationData data)
-        {
             var command = new CreateNotificationCommand
             {
-                Notification = data,
-                Type = NotificationType.iOs
+                Notification = model.GetDataByType(),
+                Type = model.Type
             };
             var result = await Mediator.Send(command);
             return Ok(result);

--- a/src/WebApi/Models/CreateNotificationModel.cs
+++ b/src/WebApi/Models/CreateNotificationModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Domain.Common;
+using Domain.Enums;
+using Infrastructure.Services.AndroidNotification;
+using Infrastructure.Services.IOsNotification;
+
+namespace WebApi.Models
+{
+    public class CreateNotificationModel
+    {
+        public AndroidNotificationData AndroidData { get; set; }
+        public IOsNotificationData IOsData { get; set; }
+        public NotificationType Type { get; set; }
+
+        public INotificationData GetDataByType()
+        {
+            return Type switch
+            {
+                NotificationType.iOs => IOsData,
+                NotificationType.Android => AndroidData,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+    }
+}


### PR DESCRIPTION
According to the terms of reference, the interface must contain only one `created` method. But in the first implementation, I made 2 methods with only difference in path (like this `create/{type:NotificationType}`. 
So, For me first implementation looks better than one method for both devices